### PR TITLE
chain: avoid locking the chain on duplicate pows

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1724,8 +1724,8 @@ void database::_apply_block( const signed_block& next_block )
             auto it = rewarded_wallets.find(wallet_name);
             if (it != rewarded_wallets.end())
             {
-               wlog("!!!!!! Wallet ${w} already rewarded!", ("w", wallet_name));
-               throw operation_validate_exception();
+               wlog("!!!!!! Wallet ${w} already rewarded, discarding duplicate operation!", ("w", wallet_name));
+               continue;
             }
             rewarded_wallets.insert(wallet_name);
          }


### PR DESCRIPTION
If a miner achieves duplicate pow, because the block is broadcast ahead
of time, all other miners attempting to mint a block containing the
winning tx end up in a lock being unable to broadcast a block contianing
the pending tx.

Instead of exploding on this condition, just skip over the operation
application and let the game roll on. They did the work, at least once.