### PR TITLE
p2p: add a set of default seed nodes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -137,7 +137,6 @@ task :run do
       shared-file-dir = "blockchain"
       shared-file-size = 12G
       p2p-endpoint = #{my_host}:#{2001 + instance_index}
-      p2p-seed-node = #{seed_hosts.join(" ")}
       webserver-http-endpoint = #{my_host}:#{8751 + instance_index * 2}
 
       miner = ["#{wallet}","#{wif}"]
@@ -147,8 +146,10 @@ task :run do
       mining-reward-key = #{witness_private_key}
 
       enable-stale-production = #{mining_disabled? ? 'false' : 'true'}
-      required-participation = 0
     )))
+    if seed_hosts && seed_hosts.any?
+      f.puts "p2p-seed-node = #{seed_hosts.join(" ")}"
+    end
   end
   $stderr.puts(File.read("#{data_dir}/config.ini"))
 

--- a/libraries/plugins/p2p/include/xgt/plugins/p2p/p2p_default_seeds.hpp
+++ b/libraries/plugins/p2p/include/xgt/plugins/p2p/p2p_default_seeds.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <vector>
 
 namespace xgt{ namespace plugins { namespace p2p {
@@ -7,8 +8,14 @@ namespace xgt{ namespace plugins { namespace p2p {
 #ifdef IS_TEST_NET
 const std::vector< std::string > default_seeds;
 #else
-// TODO: Replace these
 const std::vector< std::string > default_seeds = {
+    "98.33.76.100",
+    "xgt.rag.pub",
+    "xgt2.rag.pub",
+    "45.138.27.42",
+    "68.129.31.2",
+    "116.202.114.157",
+    "195.201.167.19"
 };
 #endif
 


### PR DESCRIPTION
When XGT_SEED_HOST isn't set, let the defaults be used.