### PR TITLE
Store mining metadata on block

### DIFF
--- a/libraries/chain/xgt_evaluator.cpp
+++ b/libraries/chain/xgt_evaluator.cpp
@@ -918,6 +918,12 @@ void pow_evaluator::do_apply( const pow_operation& o )
 {
    database& db = this->db();
 
+   uint32_t head_num = db.head_block_num();
+   if (head_num >= 1209600)
+   {
+      return;
+   }
+
    const auto& dgp = db.get_dynamic_global_properties();
    uint32_t target_pow = db.get_pow_summary_target();
 

--- a/libraries/chain/xgt_evaluator.cpp
+++ b/libraries/chain/xgt_evaluator.cpp
@@ -918,6 +918,7 @@ void pow_evaluator::do_apply( const pow_operation& o )
 {
    database& db = this->db();
 
+   /// @since 1.3.0 store mining metadata on block
    uint32_t head_num = db.head_block_num();
    if (head_num >= 1209600)
    {

--- a/libraries/plugins/p2p/p2p_plugin.cpp
+++ b/libraries/plugins/p2p/p2p_plugin.cpp
@@ -560,6 +560,7 @@ void p2p_plugin::set_program_options( bpo::options_description& cli, bpo::option
    }
 
    cfg.add_options()
+      ("from-genesis", bpo::value<bool>()->default_value( false ), "Don't wait to start mining (from genesis)")
       ("p2p-endpoint", bpo::value<string>()->implicit_value("127.0.0.1:9876"), "The local IP address and port to listen for incoming connections.")
       ("p2p-max-connections", bpo::value<uint32_t>(), "Maxmimum number of incoming connections on P2P endpoint.")
       ("seed-node", bpo::value<vector<string>>()->composing(), "The IP address and port of a remote peer to sync with. Deprecated in favor of p2p-seed-node.")
@@ -576,7 +577,7 @@ void p2p_plugin::plugin_initialize(const boost::program_options::variables_map& 
 {
    my = std::make_unique< detail::p2p_plugin_impl >( appbase::app().get_plugin< plugins::chain::chain_plugin >() );
 
-   my->ready_to_mine = false;
+   my->ready_to_mine = options.at( "from-genesis" ).as< bool >();
 
    if( options.count( "p2p-endpoint" ) )
       my->endpoint = fc::ip::endpoint::from_string( options.at( "p2p-endpoint" ).as< string >() );

--- a/libraries/plugins/witness/witness_plugin.cpp
+++ b/libraries/plugins/witness/witness_plugin.cpp
@@ -322,9 +322,13 @@ namespace detail {
                   _db.push_block(block, (uint32_t)0);
                   appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_block( block );
 
-                  wlog( "Broadcasting Proof of Work for ${miner}", ("miner", miner) );
-                  _db.push_transaction( trx );
-                  appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_transaction( trx );
+                  /// @since 1.3.0 store mining metadata on block
+                  if (block_num < 1209600)
+                  {
+                     wlog( "Broadcasting Proof of Work for ${miner}", ("miner", miner) );
+                     _db.push_transaction( trx );
+                     appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_transaction( trx );
+                  }
 
                   ++this->_head_block_num;
                   wlog( "Broadcast succeeded!" );

--- a/libraries/plugins/witness/witness_plugin.cpp
+++ b/libraries/plugins/witness/witness_plugin.cpp
@@ -318,6 +318,7 @@ namespace detail {
                   wlog("Mined block proceeding #${n} with timestamp ${t} at time ${c}", ("n", block_num)("t", head_block_time)("c", fc::time_point::now()));
                   fc::time_point now = fc::time_point::now();
                   auto block = _chain_plugin.generate_block( now, miner, pk, _production_skip_flags);
+                  block.pow_summary = work->pow_summary;
                   _db.push_block(block, (uint32_t)0);
                   appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_block( block );
 

--- a/libraries/protocol/include/xgt/protocol/block_header.hpp
+++ b/libraries/protocol/include/xgt/protocol/block_header.hpp
@@ -28,6 +28,8 @@ namespace xgt { namespace protocol {
       checksum_type                 transaction_merkle_root;
       block_header_extensions_type  extensions;
 
+      uint32_t pow_summary = 0;
+
       static uint32_t num_from_id(const block_id_type& id);
    };
 


### PR DESCRIPTION
* Prevent issues with double-rewarding or missing rewards, by storing mining metadata on the block itself, instead of inserting another transaction after the fact
* Fix allowing for starting testnets from genesis, by adding a config variable, `"from-genesis"`