### PR TITLE
WIP: One reward per block

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1706,7 +1706,7 @@ void database::_apply_block( const signed_block& next_block )
    /// @since 1.2.0 reject blocks with duplicate rewards
    /// @since 1.3.0 deprecated
    uint32_t head_num = head_block_num();
-   if (head_num >= 907200 && head_num < 1814400)
+   if (head_num >= 907200 && head_num < 2116800)
    {
       std::set< wallet_name_type > rewarded_wallets;
       for( const auto& trx : next_block.transactions )
@@ -1731,7 +1731,7 @@ void database::_apply_block( const signed_block& next_block )
    }
 
    /// @since 1.3.0 reward the first miner, on the current ("next") block
-   if (head_num >= 1814400)
+   if (head_num >= 2116800)
    {
       optional< wallet_name_type > rewarded_miner;
       for( const auto& trx : next_block.transactions )

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1702,7 +1702,7 @@ void database::_apply_block( const signed_block& next_block )
    // process_required_actions( req_actions );
    // process_optional_actions( opt_actions );
 
-   // Ensure no duplicate mining rewards
+   /// Ensure no duplicate mining rewards
    /// @since 1.2.0 reject blocks with duplicate rewards
    /// @since 1.3.0 deprecated
    uint32_t head_num = head_block_num();
@@ -1753,7 +1753,7 @@ void database::_apply_block( const signed_block& next_block )
 
             const auto& work = o.work.get< sha2_pow >();
             FC_ASSERT( work.pow_summary < target_pow, "Insufficient work difficulty. Work: ${w}, Target: ${t}", ("w",work.pow_summary)("t", target_pow) );
-            FC_ASSERT( work.prev_block < next_block.previous, "Op prev block id ${m} doesn't match prev block id ${n} do not match.", ("m",work.prev_block)("n",next_block.previous) );
+            FC_ASSERT( work.prev_block == next_block.previous, "Op prev block id ${m} doesn't match prev block id ${n} do not match.", ("m",work.prev_block)("n",next_block.previous) );
             FC_ASSERT( next_block.witness == wallet_name, "Block miner name ${m} and op miner name (${n}) do not match.", ("m",next_block.witness)("n",wallet_name) );
             wallet_name_type worker_account = work.input.worker_account;
 
@@ -1765,7 +1765,7 @@ void database::_apply_block( const signed_block& next_block )
             double value = base_reward.amount.value * (1.0 / static_cast<double>(divisor));
             long price = static_cast<long>(floor(value));
             asset reward = asset(price, base_reward.symbol);
-            wlog("!!!!!! Mining reward for ${w} amount ${r}", ("w",worker_account)("r",reward));
+            ilog("Mining reward for ${w} amount ${r}", ("w",worker_account)("r",reward));
 
             const wallet_object* w = find_account( worker_account );
             const witness_object* cur_witness = find_witness( worker_account );
@@ -1786,7 +1786,6 @@ void database::_apply_block( const signed_block& next_block )
          }
       }
    }
-
 
    // Adjust mining difficulty
    const uint32_t frequency = XGT_MINING_RECALC_EVERY_N_BLOCKS;

--- a/libraries/chain/xgt_evaluator.cpp
+++ b/libraries/chain/xgt_evaluator.cpp
@@ -918,6 +918,12 @@ void pow_evaluator::do_apply( const pow_operation& o )
 {
    database& db = this->db();
 
+   uint32_t head_num = db.head_block_num();
+   if (head_num >= 181440)
+   {
+      return;
+   }
+
    const auto& dgp = db.get_dynamic_global_properties();
    uint32_t target_pow = db.get_pow_summary_target();
 

--- a/libraries/chain/xgt_evaluator.cpp
+++ b/libraries/chain/xgt_evaluator.cpp
@@ -920,9 +920,7 @@ void pow_evaluator::do_apply( const pow_operation& o )
 
    uint32_t head_num = db.head_block_num();
    if (head_num >= 181440)
-   {
       return;
-   }
 
    const auto& dgp = db.get_dynamic_global_properties();
    uint32_t target_pow = db.get_pow_summary_target();

--- a/libraries/plugins/chain/chain_plugin.cpp
+++ b/libraries/plugins/chain/chain_plugin.cpp
@@ -37,7 +37,13 @@ namespace asio = boost::asio;
 
 struct generate_block_request
 {
-   generate_block_request( const fc::time_point_sec w, const wallet_name_type& wo, const fc::ecc::private_key& priv_key, const xgt::chain::signed_transaction& br, uint32_t s ) :
+   generate_block_request(
+      const fc::time_point_sec w,
+      const wallet_name_type& wo,
+      const fc::ecc::private_key& priv_key,
+      fc::optional< xgt::chain::signed_transaction > br,
+      uint32_t s
+   ) :
       when( w ),
       witness_recovery( wo ),
       block_signing_private_key( priv_key ),
@@ -47,7 +53,7 @@ struct generate_block_request
    const fc::time_point_sec when;
    const wallet_name_type& witness_recovery;
    const fc::ecc::private_key& block_signing_private_key;
-   const xgt::chain::signed_transaction block_reward;
+   fc::optional< xgt::chain::signed_transaction > block_reward;
    uint32_t skip;
    signed_block block;
 };
@@ -185,7 +191,7 @@ struct write_request_visitor
             req->when,
             req->witness_recovery,
             req->block_signing_private_key,
-	    req->block_reward,
+            fc::optional< xgt::chain::signed_transaction >(req->block_reward),
             req->skip
             );
 
@@ -736,7 +742,7 @@ xgt::chain::signed_block chain_plugin::generate_block(
    const fc::time_point_sec when,
    const wallet_name_type& witness_recovery,
    const fc::ecc::private_key& block_signing_private_key,
-   const xgt::chain::signed_transaction& block_reward,
+   fc::optional< xgt::chain::signed_transaction > block_reward,
    uint32_t skip )
 {
    generate_block_request req( when, witness_recovery, block_signing_private_key, block_reward, skip );

--- a/libraries/plugins/chain/chain_plugin.cpp
+++ b/libraries/plugins/chain/chain_plugin.cpp
@@ -37,15 +37,17 @@ namespace asio = boost::asio;
 
 struct generate_block_request
 {
-   generate_block_request( const fc::time_point_sec w, const wallet_name_type& wo, const fc::ecc::private_key& priv_key, uint32_t s ) :
+   generate_block_request( const fc::time_point_sec w, const wallet_name_type& wo, const fc::ecc::private_key& priv_key, const xgt::chain::signed_transaction& br, uint32_t s ) :
       when( w ),
       witness_recovery( wo ),
       block_signing_private_key( priv_key ),
+      block_reward( br ), 
       skip( s ) {}
 
    const fc::time_point_sec when;
    const wallet_name_type& witness_recovery;
    const fc::ecc::private_key& block_signing_private_key;
+   const xgt::chain::signed_transaction block_reward;
    uint32_t skip;
    signed_block block;
 };
@@ -183,6 +185,7 @@ struct write_request_visitor
             req->when,
             req->witness_recovery,
             req->block_signing_private_key,
+	    req->block_reward,
             req->skip
             );
 
@@ -733,9 +736,10 @@ xgt::chain::signed_block chain_plugin::generate_block(
    const fc::time_point_sec when,
    const wallet_name_type& witness_recovery,
    const fc::ecc::private_key& block_signing_private_key,
+   const xgt::chain::signed_transaction& block_reward,
    uint32_t skip )
 {
-   generate_block_request req( when, witness_recovery, block_signing_private_key, skip );
+   generate_block_request req( when, witness_recovery, block_signing_private_key, block_reward, skip );
    boost::promise< void > prom;
    write_context cxt;
    cxt.req_ptr = &req;

--- a/libraries/plugins/chain/include/xgt/plugins/chain/abstract_block_producer.hpp
+++ b/libraries/plugins/chain/include/xgt/plugins/chain/abstract_block_producer.hpp
@@ -14,7 +14,7 @@ public:
       fc::time_point_sec when,
       const xgt::chain::wallet_name_type& witness_recovery,
       const fc::ecc::private_key& block_signing_private_key,
-      const xgt::chain::signed_transaction& block_reward,
+      fc::optional< xgt::chain::signed_transaction > block_reward,
       uint32_t skip = xgt::chain::database::skip_nothing) = 0;
 };
 

--- a/libraries/plugins/chain/include/xgt/plugins/chain/abstract_block_producer.hpp
+++ b/libraries/plugins/chain/include/xgt/plugins/chain/abstract_block_producer.hpp
@@ -14,6 +14,7 @@ public:
       fc::time_point_sec when,
       const xgt::chain::wallet_name_type& witness_recovery,
       const fc::ecc::private_key& block_signing_private_key,
+      const xgt::chain::signed_transaction& block_reward,
       uint32_t skip = xgt::chain::database::skip_nothing) = 0;
 };
 

--- a/libraries/plugins/chain/include/xgt/plugins/chain/chain_plugin.hpp
+++ b/libraries/plugins/chain/include/xgt/plugins/chain/chain_plugin.hpp
@@ -51,7 +51,7 @@ public:
       const fc::time_point_sec when,
       const wallet_name_type& witness_recovery,
       const fc::ecc::private_key& block_signing_private_key,
-      const xgt::chain::signed_transaction& block_reward,
+      fc::optional< xgt::chain::signed_transaction > block_reward,
       uint32_t skip = database::skip_nothing
       );
 

--- a/libraries/plugins/chain/include/xgt/plugins/chain/chain_plugin.hpp
+++ b/libraries/plugins/chain/include/xgt/plugins/chain/chain_plugin.hpp
@@ -51,6 +51,7 @@ public:
       const fc::time_point_sec when,
       const wallet_name_type& witness_recovery,
       const fc::ecc::private_key& block_signing_private_key,
+      const xgt::chain::signed_transaction& block_reward,
       uint32_t skip = database::skip_nothing
       );
 

--- a/libraries/plugins/debug_node/debug_node_plugin.cpp
+++ b/libraries/plugins/debug_node/debug_node_plugin.cpp
@@ -253,7 +253,11 @@ void debug_node_plugin::debug_generate_blocks(
             break;
       }
 
-      bp.generate_block( scheduled_time, scheduled_witness_name, *debug_private_key, args.skip );
+      // For expediency, this is just a hacked together block; a less-fake version would be a 
+      // PoW operation.
+      protocol::signed_transaction fake_block_reward;
+
+      bp.generate_block( scheduled_time, scheduled_witness_name, *debug_private_key, fake_block_reward, args.skip );
       ++produced;
       slot = new_slot;
    }

--- a/libraries/plugins/p2p/p2p_plugin.cpp
+++ b/libraries/plugins/p2p/p2p_plugin.cpp
@@ -576,7 +576,7 @@ void p2p_plugin::plugin_initialize(const boost::program_options::variables_map& 
 {
    my = std::make_unique< detail::p2p_plugin_impl >( appbase::app().get_plugin< plugins::chain::chain_plugin >() );
 
-   my->ready_to_mine = false;
+   my->ready_to_mine = true; // TODO: Change this back
 
    if( options.count( "p2p-endpoint" ) )
       my->endpoint = fc::ip::endpoint::from_string( options.at( "p2p-endpoint" ).as< string >() );

--- a/libraries/plugins/p2p/p2p_plugin.cpp
+++ b/libraries/plugins/p2p/p2p_plugin.cpp
@@ -576,7 +576,7 @@ void p2p_plugin::plugin_initialize(const boost::program_options::variables_map& 
 {
    my = std::make_unique< detail::p2p_plugin_impl >( appbase::app().get_plugin< plugins::chain::chain_plugin >() );
 
-   my->ready_to_mine = true; // TODO: Change this back
+   my->ready_to_mine = false;
 
    if( options.count( "p2p-endpoint" ) )
       my->endpoint = fc::ip::endpoint::from_string( options.at( "p2p-endpoint" ).as< string >() );

--- a/libraries/plugins/witness/block_producer.cpp
+++ b/libraries/plugins/witness/block_producer.cpp
@@ -16,7 +16,7 @@
 
 namespace xgt { namespace plugins { namespace witness {
 
-chain::signed_block block_producer::generate_block(fc::time_point_sec when, const chain::wallet_name_type& witness_recovery, const fc::ecc::private_key& block_signing_private_key, uint32_t skip)
+chain::signed_block block_producer::generate_block(fc::time_point_sec when, const chain::wallet_name_type& witness_recovery, const fc::ecc::private_key& block_signing_private_key, const xgt::chain::signed_transaction& trx, uint32_t skip)
 {
    chain::signed_block result;
    try
@@ -29,7 +29,7 @@ chain::signed_block block_producer::generate_block(fc::time_point_sec when, cons
          {
             try
             {
-               result = _generate_block( when, witness_recovery, block_signing_private_key );
+               result = _generate_block( when, witness_recovery, block_signing_private_key, trx );
             }
             FC_CAPTURE_AND_RETHROW( (witness_recovery) )
          });
@@ -44,7 +44,7 @@ chain::signed_block block_producer::generate_block(fc::time_point_sec when, cons
    return result;
 }
 
-chain::signed_block block_producer::_generate_block(fc::time_point_sec when, const chain::wallet_name_type& witness, const fc::ecc::private_key& block_signing_private_key)
+chain::signed_block block_producer::_generate_block(fc::time_point_sec when, const chain::wallet_name_type& witness, const fc::ecc::private_key& block_signing_private_key, const xgt::chain::signed_transaction& block_reward)
 { try {
    uint32_t skip = _db.get_node_properties().skip_flags;
    // const auto& witness_obj = _db.get_witness( witness );
@@ -70,7 +70,7 @@ chain::signed_block block_producer::_generate_block(fc::time_point_sec when, con
 
    adjust_hardfork_version_vote( _db.get_witness( witness ), pending_block );
 
-   apply_pending_transactions( witness, when, pending_block );
+   apply_pending_transactions( witness, when, pending_block, block_reward );
 
    // We have temporarily broken the invariant that
    // _pending_tx_session is the result of applying _pending_tx, as
@@ -120,7 +120,8 @@ void block_producer::adjust_hardfork_version_vote(const chain::witness_object& w
 void block_producer::apply_pending_transactions(
         const chain::wallet_name_type& witness_recovery,
         fc::time_point_sec when,
-        chain::signed_block& pending_block)
+        chain::signed_block& pending_block,
+	const xgt::chain::signed_transaction& block_reward )
 {
    size_t total_block_size = fc::raw::pack_size( pending_block );
    total_block_size += sizeof( uint32_t ); // Transaction vector length
@@ -153,7 +154,36 @@ void block_producer::apply_pending_transactions(
              dgp.current_witness = witness_recovery;
           });
 
+
    uint64_t postponed_tx_count = 0;
+
+
+      // postpone transaction if it would make block too big
+
+      uint64_t new_total_size = total_block_size + fc::raw::pack_size( block_reward );
+      if (new_total_size >= maximum_transaction_partition_size)
+      {
+          postponed_tx_count++;
+      }
+      else
+      {
+          try
+          {
+              auto temp_session = _db.start_undo_session();
+              _db.apply_transaction(block_reward, _db.get_node_properties().skip_flags);
+              temp_session.squash();
+
+              total_block_size = new_total_size;
+              pending_block.transactions.push_back(block_reward);
+          }
+          catch (const fc::exception& e)
+          {
+              // Do nothing, transaction will not be re-applied
+              //wlog( "Transaction was not processed while generating block due to ${e}", ("e", e) );
+              //wlog( "The transaction was ${t}", ("t", tx) );
+          }
+      }
+
    // pop pending state (reset to head block state)
    for( const chain::signed_transaction& tx : _db._pending_tx )
    {

--- a/libraries/plugins/witness/include/xgt/plugins/witness/block_producer.hpp
+++ b/libraries/plugins/witness/include/xgt/plugins/witness/block_producer.hpp
@@ -22,6 +22,7 @@ public:
       fc::time_point_sec when,
       const chain::wallet_name_type& witness_recovery,
       const fc::ecc::private_key& block_signing_private_key,
+      const xgt::chain::signed_transaction& trx,
       uint32_t skip = chain::database::skip_nothing);
 
 private:
@@ -30,14 +31,16 @@ private:
    chain::signed_block _generate_block(
       fc::time_point_sec when,
       const chain::wallet_name_type& witness_recovery,
-      const fc::ecc::private_key& block_signing_private_key);
+      const fc::ecc::private_key& block_signing_private_key,
+      const xgt::chain::signed_transaction& block_reward);
 
    void adjust_hardfork_version_vote( const chain::witness_object& witness, chain::signed_block& pending_block );
 
    void apply_pending_transactions(
       const chain::wallet_name_type& witness_recovery,
       fc::time_point_sec when,
-      chain::signed_block& pending_block);
+      chain::signed_block& pending_block,
+      const xgt::chain::signed_transaction& trx);
 };
 
 } } } // xgt::plugins::witness

--- a/libraries/plugins/witness/include/xgt/plugins/witness/block_producer.hpp
+++ b/libraries/plugins/witness/include/xgt/plugins/witness/block_producer.hpp
@@ -22,8 +22,9 @@ public:
       fc::time_point_sec when,
       const chain::wallet_name_type& witness_recovery,
       const fc::ecc::private_key& block_signing_private_key,
-      const xgt::chain::signed_transaction& trx,
-      uint32_t skip = chain::database::skip_nothing);
+      fc::optional< xgt::chain::signed_transaction > trx,
+      uint32_t skip = chain::database::skip_nothing
+   );
 
 private:
    chain::database& _db;
@@ -32,7 +33,8 @@ private:
       fc::time_point_sec when,
       const chain::wallet_name_type& witness_recovery,
       const fc::ecc::private_key& block_signing_private_key,
-      const xgt::chain::signed_transaction& block_reward);
+      fc::optional< xgt::chain::signed_transaction > block_reward
+   );
 
    void adjust_hardfork_version_vote( const chain::witness_object& witness, chain::signed_block& pending_block );
 
@@ -40,7 +42,8 @@ private:
       const chain::wallet_name_type& witness_recovery,
       fc::time_point_sec when,
       chain::signed_block& pending_block,
-      const xgt::chain::signed_transaction& trx);
+      fc::optional< xgt::chain::signed_transaction > trx
+   );
 };
 
 } } } // xgt::plugins::witness

--- a/libraries/plugins/witness/witness_plugin.cpp
+++ b/libraries/plugins/witness/witness_plugin.cpp
@@ -315,7 +315,7 @@ namespace detail {
                   wlog("Mined block proceeding #${n} with timestamp ${t} at time ${c}", ("n", block_num)("t", head_block_time)("c", fc::time_point::now()));
                   fc::time_point now = fc::time_point::now();
                   uint32_t head_num = _db.head_block_num();
-                  if (head_num < 1814400)
+                  if (head_num < 2116800)
                   {
                      auto block_reward = fc::optional< protocol::signed_transaction >();
                      auto block = _chain_plugin.generate_block(

--- a/libraries/plugins/witness/witness_plugin.cpp
+++ b/libraries/plugins/witness/witness_plugin.cpp
@@ -314,19 +314,37 @@ namespace detail {
                {
                   wlog("Mined block proceeding #${n} with timestamp ${t} at time ${c}", ("n", block_num)("t", head_block_time)("c", fc::time_point::now()));
                   fc::time_point now = fc::time_point::now();
-                  auto block = _chain_plugin.generate_block(
-                     now,
-                     miner,
-                     pk,
-                     fc::optional< protocol::signed_transaction >(trx),
-                     _production_skip_flags
-                  );
-                  _db.push_block(block, (uint32_t)0);
-                  appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_block( block );
-
-                  wlog( "Broadcasting Proof of Work for ${miner}", ("miner", miner) );
-                  // _db.push_transaction( trx );
-                  // appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_transaction( trx );
+                  uint32_t head_num = _db.head_block_num();
+                  if (head_num < 1814400)
+                  {
+                     auto block_reward = fc::optional< protocol::signed_transaction >();
+                     auto block = _chain_plugin.generate_block(
+                        now,
+                        miner,
+                        pk,
+                        block_reward,
+                        _production_skip_flags
+                     );
+                     _db.push_block(block, (uint32_t)0);
+                     appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_block( block );
+                     wlog( "Broadcasting Proof of Work for ${miner}", ("miner", miner) );
+                     _db.push_transaction( trx );
+                     appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_transaction( trx );
+                  }
+                  else
+                  {
+                     auto block_reward = fc::optional< protocol::signed_transaction >(trx);
+                     auto block = _chain_plugin.generate_block(
+                        now,
+                        miner,
+                        pk,
+                        block_reward,
+                        _production_skip_flags
+                     );
+                     _db.push_block(block, (uint32_t)0);
+                     appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().broadcast_block( block );
+                     wlog( "Broadcasting Proof of Work for ${miner}", ("miner", miner) );
+                  }
 
                   ++this->_head_block_num;
                   wlog( "Broadcast succeeded!" );
@@ -401,11 +419,12 @@ namespace detail {
          {
             wlog("Generating genesis block...");
             auto pair = _private_keys.begin();
+            auto block_reward = fc::optional< xgt::chain::signed_transaction >();
             auto block = _chain_plugin.generate_block(
                now,
                XGT_INIT_MINER_NAME,
                pair->second,
-               fc::optional< xgt::chain::signed_transaction >(),
+               block_reward,
                _production_skip_flags
             );
             _db.push_block(block, (uint32_t)0);


### PR DESCRIPTION
Inserts reward op into the upcoming block itself, simplifying the tracking of rewards.

Alternatives were:

* Store reward metadata on block itself (breaking change)
* Use more sophisticated heuristics to track rewards and their blocks

- [x] Update reward behavior
- [x] Update mining broadcast behavior
- [x] Use overloading to allow `_block_producer.generate_block` to take a `trx` or not