### PR TITLE
net: send closing notification to peers

### DIFF
--- a/libraries/net/message_oriented_connection.cpp
+++ b/libraries/net/message_oriented_connection.cpp
@@ -278,6 +278,7 @@ namespace graphene { namespace net {
     void message_oriented_connection_impl::close_connection()
     {
       VERIFY_CORRECT_THREAD();
+      _sock.flush();
       _sock.close();
     }
 

--- a/libraries/net/peer_connection.cpp
+++ b/libraries/net/peer_connection.cpp
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <graphene/net/core_messages.hpp>
 #include <graphene/net/peer_connection.hpp>
 #include <graphene/net/exceptions.hpp>
 #include <graphene/net/config.hpp>
@@ -126,6 +127,8 @@ namespace graphene { namespace net
 
       try
       {
+        closing_connection_message message = closing_connection_message();
+        send_message(message);
         dlog("calling close_connection()");
         close_connection();
         dlog("close_connection completed normally");


### PR DESCRIPTION
This prevents peers from shutting out nodes due to non-response during
linger.