### PR TITLE
genesis: fix mining on genesis

### DIFF
--- a/libraries/plugins/p2p/p2p_plugin.cpp
+++ b/libraries/plugins/p2p/p2p_plugin.cpp
@@ -576,8 +576,6 @@ void p2p_plugin::plugin_initialize(const boost::program_options::variables_map& 
 {
    my = std::make_unique< detail::p2p_plugin_impl >( appbase::app().get_plugin< plugins::chain::chain_plugin >() );
 
-   my->ready_to_mine = false;
-
    if( options.count( "p2p-endpoint" ) )
       my->endpoint = fc::ip::endpoint::from_string( options.at( "p2p-endpoint" ).as< string >() );
 
@@ -631,6 +629,9 @@ void p2p_plugin::plugin_initialize(const boost::program_options::variables_map& 
          }
       }
    }
+
+   // If there are no needs, we will never become "in-sync", we're ready to mine.
+   my->ready_to_mine = my->seeds.empty();
 
    my->force_validate = options.at( "p2p-force-validate" ).as< bool >();
 
@@ -787,6 +788,8 @@ void p2p_plugin::set_block_production( bool producing_blocks )
 }
 
 bool p2p_plugin::ready_to_mine() {
+   if (my->ready_to_mine) return true;
+
    return my->ready_to_mine;
 }
 

--- a/libraries/plugins/witness/witness_plugin.cpp
+++ b/libraries/plugins/witness/witness_plugin.cpp
@@ -91,6 +91,7 @@ namespace detail {
       boost::signals2::connection   _post_apply_block_conn;
       boost::signals2::connection   _pre_apply_operation_conn;
       boost::signals2::connection   _post_apply_operation_conn;
+      boost::signals2::connection   _chain_sync;
 
       std::shared_ptr< witness::block_producer >                       _block_producer;
 
@@ -362,7 +363,7 @@ namespace detail {
    }
 
    void witness_plugin_impl::schedule_production_loop() {
-      if (!appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().ready_to_mine()) {
+      if (_db.head_block_num() != 0 && !appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().ready_to_mine()) {
          _timer.expires_from_now( boost::posix_time::milliseconds( 1000 ) );
          _timer.async_wait( boost::bind( &witness_plugin_impl::schedule_production_loop, this ) );
          return;
@@ -582,7 +583,10 @@ void witness_plugin::plugin_startup()
             new_chain_banner( d );
          my->_production_skip_flags |= chain::database::skip_undo_history_check;
 
-         my->schedule_production_loop();
+         plugins::chain::chain_plugin* chain = appbase::app().find_plugin< plugins::chain::chain_plugin >();
+         my->_chain_sync = chain->on_sync.connect( 0, [this]() {
+            my->schedule_production_loop();
+         });
       } else
          elog("No witnesses configured! Please add witness IDs and private keys to configuration.");
       }


### PR DESCRIPTION
If there are no seeds, we're in sync already.
Start mining after the chain database is loaded, not before.