### PR TITLE
Fix block reward issues from 1.4.1 inline rewards

### DIFF
--- a/libraries/plugins/witness/witness_plugin.cpp
+++ b/libraries/plugins/witness/witness_plugin.cpp
@@ -354,7 +354,6 @@ namespace detail {
                   wlog( "Broadcast failed!" );
                   wdump((e.to_detail_string()));
                }
-               schedule_production_loop();
                return;
             }
          }
@@ -372,17 +371,13 @@ namespace detail {
             this->_head_block_num = head_block_num;
             break;
          }
-         if (this->_is_braking) {
-            break;
-         }
-      }
-      if (!this->_is_braking)
-      {
-         schedule_production_loop();
       }
    }
 
    void witness_plugin_impl::schedule_production_loop() {
+      if (this->_is_braking) {
+         return;
+      }
       if (!appbase::app().get_plugin< xgt::plugins::p2p::p2p_plugin >().ready_to_mine()) {
          _timer.expires_from_now( boost::posix_time::milliseconds( 1000 ) );
          _timer.async_wait( boost::bind( &witness_plugin_impl::schedule_production_loop, this ) );
@@ -394,8 +389,6 @@ namespace detail {
 
    void witness_plugin_impl::block_production_loop()
    {
-      _is_braking = false;
-
       fc::time_point now = fc::time_point::now();
 
       if( now < fc::time_point(XGT_GENESIS_TIME) )
@@ -429,8 +422,6 @@ namespace detail {
             );
             _db.push_block(block, (uint32_t)0);
             this->_head_block_num++;
-            schedule_production_loop();
-            return;
          }
          schedule_production_loop();
          return;
@@ -461,6 +452,7 @@ namespace detail {
       {
          auto pair = _private_keys.begin();
          start_mining(pair->first, pair->second, *name_ptr);
+         schedule_production_loop();
       }
       catch( const fc::canceled_exception& )
       {

--- a/libraries/plugins/witness/witness_plugin.cpp
+++ b/libraries/plugins/witness/witness_plugin.cpp
@@ -305,8 +305,11 @@ namespace detail {
                trx.operations.push_back( op );
                trx.ref_block_num = block_num;
                trx.ref_block_prefix = work->input.prev_block._hash[1];
-               fc::time_point_sec now_sec = fc::time_point::now();
-               trx.set_expiration( now_sec + XGT_MAX_TIME_UNTIL_EXPIRATION );
+
+               // Subtle: this must not exceed head_block_time + XGT_MAX_TIME_UNTIL_EXPIRATION or it will be
+               // rejected by the expiration validation.
+               trx.set_expiration( head_block_time + XGT_MAX_TIME_UNTIL_EXPIRATION );
+
                trx.sign( pk, XGT_CHAIN_ID, fc::ecc::fc_canonical );
 
                wlog( "Broadcasting..." );


### PR DESCRIPTION
- Block reward tx's can no longer fail silently, and empty blocks will no longer be produced by miners.
- External pow tx's, say from stale miners, are no longer included, and thus can no longer poison other miners.
- pow tx expiration is clamped within a valid time range