### PR TITLE
p2p: connect to seeds after configuration

### DIFF
--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -4672,7 +4672,7 @@ namespace graphene { namespace net {
                 error_message_stream << "\nStill waiting for port " << listen_endpoint.port() << " to become available\n";
               }
               std::string error_message = error_message_stream.str();
-              ulog(error_message);
+              wlog(error_message);
               _delegate->error_encountered( error_message, fc::oexception() );
               fc::usleep( fc::seconds(GRAPHENE_NET_PORT_WAIT_DELAY_SECONDS) );
             }

--- a/libraries/plugins/p2p/p2p_plugin.cpp
+++ b/libraries/plugins/p2p/p2p_plugin.cpp
@@ -661,20 +661,6 @@ void p2p_plugin::plugin_startup()
          my->node->listen_on_endpoint(*my->endpoint, true);
       }
 
-      for( const auto& seed : my->seeds )
-      {
-         try
-         {
-            ilog("P2P adding seed node ${s}", ("s", seed));
-            my->node->add_node(seed);
-            my->node->connect_to_endpoint(seed);
-         }
-         catch( graphene::net::already_connected_to_requested_peer& )
-         {
-            wlog( "Already connected to seed node ${s}. Is it specified twice in config?", ("s", seed) );
-         }
-      }
-
       if( my->max_connections )
       {
          if( my->config.find( "maximum_number_of_connections" ) != my->config.end() )
@@ -690,6 +676,20 @@ void p2p_plugin::plugin_startup()
 
       ilog("Connecting to P2P network...");
       my->node->connect_to_p2p_network();
+
+      for( const auto& seed : my->seeds )
+      {
+         try
+         {
+            ilog("P2P adding seed node ${s}", ("s", seed));
+            my->node->add_node(seed);
+            my->node->connect_to_endpoint(seed);
+         }
+         catch( graphene::net::already_connected_to_requested_peer& )
+         {
+            wlog( "Already connected to seed node ${s}. Is it specified twice in config?", ("s", seed) );
+         }
+      }
 
       block_id_type block_id;
       my->chain.db().with_read_lock( [&]()


### PR DESCRIPTION
+ send the listen socket binding error log to somewhere people can see.

Peers were regularly observing ephemeral source addresses which was in
part due to this code being out of order - the seeds would receive
connections from ephemeral source ports instead of the desired port that
matches the listen socket. This poisons peerdbs across the network.